### PR TITLE
Reject reservation requests missing checkin or checkout dates

### DIFF
--- a/.byebug_history
+++ b/.byebug_history
@@ -1,0 +1,3 @@
+exit
+checkout
+checkin

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -5,17 +5,21 @@ class CartsController < ApplicationController
     session[:checkout] = nil
     checkin = params[:date][:checkin_date]
     checkout = params[:date][:checkout_date]
-    reserved_dates = Reservation.dates_reserved(
-      params[:id], checkin, checkout
-    )
-    if Date.strptime(checkin, "%m/%d/%Y") > Date.strptime(checkout, "%m/%d/%Y")
-      flash[:error] = "You must select a checkin date before your checkout date"
-    elsif reserved_dates.empty?
-      @cart.add_home(params[:id], checkin, checkout)
-      session[:cart] = @cart.contents
-      flash[:success] = "You've added this reservation to your cart"
+    if checkin == "" || checkout == ""
+      flash[:error] = "You must have a checkin and checkout date"
     else
-      flash[:error] = "This home is already reserved on #{reserved_dates.join(", ")}"
+      reserved_dates = Reservation.dates_reserved(
+        params[:id], checkin, checkout
+      )
+      if Date.strptime(checkin, "%m/%d/%Y") > Date.strptime(checkout, "%m/%d/%Y")
+        flash[:error] = "You must select a checkin date before your checkout date"
+      elsif reserved_dates.empty?
+        @cart.add_home(params[:id], checkin, checkout)
+        session[:cart] = @cart.contents
+        flash[:success] = "You've added this reservation to your cart"
+      else
+        flash[:error] = "This home is already reserved on #{reserved_dates.join(", ")}"
+      end
     end
     redirect_to request.referrer
   end

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -1,26 +1,20 @@
 class CartsController < ApplicationController
 
   def create
+    reservation_request = ReservationParser.new(params)
+    if reservation_request.missing_dates?
+      flash[:error] = "You must have a checkin and checkout date"
+    elsif reservation_request.has_checkin_after_checkout?
+      flash[:error] = "You must select a checkin date before your checkout date" 
+    elsif reservation_request.is_valid?
+      @cart.add_home(params[:id], params[:date][:checkin_date], params[:date][:checkout_date])
+      session[:cart] = @cart.contents
+      flash[:success] = "You've added this reservation to your cart"
+    else
+      flash[:error] = "This home is already reserved on #{reservation_request.reserved_dates.join(", ")}"
+    end
     session[:checkin] = nil
     session[:checkout] = nil
-    checkin = params[:date][:checkin_date]
-    checkout = params[:date][:checkout_date]
-    if checkin == "" || checkout == ""
-      flash[:error] = "You must have a checkin and checkout date"
-    else
-      reserved_dates = Reservation.dates_reserved(
-        params[:id], checkin, checkout
-      )
-      if Date.strptime(checkin, "%m/%d/%Y") > Date.strptime(checkout, "%m/%d/%Y")
-        flash[:error] = "You must select a checkin date before your checkout date"
-      elsif reserved_dates.empty?
-        @cart.add_home(params[:id], checkin, checkout)
-        session[:cart] = @cart.contents
-        flash[:success] = "You've added this reservation to your cart"
-      else
-        flash[:error] = "This home is already reserved on #{reserved_dates.join(", ")}"
-      end
-    end
     redirect_to request.referrer
   end
 

--- a/app/models/#reservation_parser.rb#
+++ b/app/models/#reservation_parser.rb#
@@ -1,0 +1,25 @@
+class ReservationParser < SimpleDelegator
+
+  attr_reader :reserved_dates
+  
+  def initialize(params)
+    @checkin = params[:date][:checkin_date]
+    @checkout = params[:date][:checkout_date]
+    @home_id = params[:id]
+  end
+
+  def missing_dates?
+    @checkin == "" || @checkout == ""
+  end
+
+  def has_checkin_after_checkout?
+    Date.strptime(@checkin, "%m/%d/%Y") > Date.strptime(@checkout, "%m/%d/%Y")
+  end
+
+  def is_valid?
+    @reserved_dates = Reservation.dates_reserved(
+      @home_id, @checkin, @checkout
+    )
+    @reserved_dates.empty?
+  end
+end

--- a/app/models/.#reservation_parser.rb
+++ b/app/models/.#reservation_parser.rb
@@ -1,0 +1,1 @@
+ashwin@Ashwins-MacBook-Pro-2.local.17697

--- a/app/models/reservation_parser.rb
+++ b/app/models/reservation_parser.rb
@@ -1,0 +1,26 @@
+class ReservationParser < SimpleDelegator
+
+  attr_reader :reserved_dates
+  
+  def initialize(params)
+    @checkin = params[:date][:checkin_date]
+    @checkout = params[:date][:checkout_date]
+    @home_id = params[:id]
+  end
+
+  def missing_dates?
+    @checkin == "" || @checkout == ""
+  end
+
+  def has_checkin_after_checkout?
+    Date.strptime(@checkin, "%m/%d/%Y") > Date.strptime(@checkout, "%m/%d/%Y")
+  end
+
+  def is_valid?
+    @reserved_dates = Reservation.dates_reserved(
+      @home_id, @checkin, @checkout
+    )
+    @reserved_dates.empty?
+  end
+  
+end

--- a/app/models/reservation_parser.rb~
+++ b/app/models/reservation_parser.rb~
@@ -1,0 +1,6 @@
+class ReservationParser < SimpleDelegator
+
+  def initialize
+  end
+  
+end

--- a/spec/features/user_must_enter_dates_to_add_home_to_cart_spec.rb
+++ b/spec/features/user_must_enter_dates_to_add_home_to_cart_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+RSpec.describe "user wants to add a home to his cart" do
+  scenario "user does not give checkin date" do
+      home = create(:home)
+      home_owner = home.user
+      visit user_home_path(home_owner.slug, home)
+
+      checkout_date = Date.parse("2017-05-06")
+
+      fill_in "date_checkout_date", with: "05/06/2017"
+
+      expect(page).to have_content("0 Reservations - $0.00")
+      click_on("Add to Cart")
+      expect(current_path).to eq(user_home_path(home_owner.slug, home))
+      expect(page).to have_content("You must have a checkin and checkout date")
+      expect(page).to have_content("0 Reservations - $0.00")    
+  end
+
+  scenario "user does not give checkout date" do
+      home = create(:home)
+      home_owner = home.user
+      visit user_home_path(home_owner.slug, home)
+
+      checkin_date = Date.parse("2017-05-02")
+      checkout_date = Date.parse("2017-05-06")
+
+      fill_in "date_checkin_date", with: "05/02/2017"
+      fill_in "date_checkout_date", with: "05/06/2017"
+
+      expect(page).to have_content("0 Reservations - $0.00")
+      click_on("Add to Cart")
+      expect(current_path).to eq(user_home_path(home_owner.slug, home))
+      expect(page).to have_content("You've added this reservation to your cart")
+      expect(page).to have_content("1 Reservation - $400.00")    
+  end
+
+  scenario "user does not give either checkin or checkout" do
+      home = create(:home)
+      home_owner = home.user
+      visit user_home_path(home_owner.slug, home)
+
+      checkin_date = Date.parse("2017-05-02")
+      checkout_date = Date.parse("2017-05-06")
+
+      fill_in "date_checkin_date", with: "05/02/2017"
+      fill_in "date_checkout_date", with: "05/06/2017"
+
+      expect(page).to have_content("0 Reservations - $0.00")
+      click_on("Add to Cart")
+      expect(current_path).to eq(user_home_path(home_owner.slug, home))
+      expect(page).to have_content("You've added this reservation to your cart")
+      expect(page).to have_content("1 Reservation - $400.00")    
+  end
+
+end

--- a/spec/features/user_must_enter_dates_to_add_home_to_cart_spec.rb~
+++ b/spec/features/user_must_enter_dates_to_add_home_to_cart_spec.rb~
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.describe "user wants to add a home to his cart" do
+  scenario "user does not give checkin date" do
+      home = create(:home)
+      home_owner = home.user
+      visit user_home_path(home_owner.slug, home)
+
+      checkout_date = Date.parse("2017-05-06")
+
+      fill_in "date_checkout_date", with: "05/06/2017"
+
+      expect(page).to have_content("0 Reservations - $0.00")
+      click_on("Add to Cart")
+      expect(current_path).to eq(user_home_path(home_owner.slug, home))
+      expect(page).to have_content("You must have a checkin and checkout date")
+      expect(page).to have_content("0 Reservation - $0.00")    
+  end
+
+  scenario "user does not give checkout date" do
+    skip
+      home = create(:home)
+      home_owner = home.user
+      visit user_home_path(home_owner.slug, home)
+
+      checkin_date = Date.parse("2017-05-02")
+      checkout_date = Date.parse("2017-05-06")
+
+      fill_in "date_checkin_date", with: "05/02/2017"
+      fill_in "date_checkout_date", with: "05/06/2017"
+
+      expect(page).to have_content("0 Reservations - $0.00")
+      click_on("Add to Cart")
+      expect(current_path).to eq(user_home_path(home_owner.slug, home))
+      expect(page).to have_content("You've added this reservation to your cart")
+      expect(page).to have_content("1 Reservation - $400.00")    
+  end
+
+  scenario "user does not give either checkin or checkout" do
+    skip
+      home = create(:home)
+      home_owner = home.user
+      visit user_home_path(home_owner.slug, home)
+
+      checkin_date = Date.parse("2017-05-02")
+      checkout_date = Date.parse("2017-05-06")
+
+      fill_in "date_checkin_date", with: "05/02/2017"
+      fill_in "date_checkout_date", with: "05/06/2017"
+
+      expect(page).to have_content("0 Reservations - $0.00")
+      click_on("Add to Cart")
+      expect(current_path).to eq(user_home_path(home_owner.slug, home))
+      expect(page).to have_content("You've added this reservation to your cart")
+      expect(page).to have_content("1 Reservation - $400.00")    
+  end
+
+end


### PR DESCRIPTION
Fixes bug in which site breaks if a user leaves checkin or checkout dates blank before adding a home to cart.

`CartsController#create` method refactored into ReservationParser model. 

Closes #120 .